### PR TITLE
ubuntu sshd integration test

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -39,4 +39,15 @@ jobs:
           py.test -v -s tests/unit/test_base_connection.py
           py.test -v -s tests/unit/test_utilities.py
           py.test -v -s tests/unit/test_ssh_autodetect.py
+  integration-test:
+    name: integration test
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earthly
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: netmiko integration test
+        run: earthly -P --ci +integration-test
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,36 @@
+all:
+    BUILD +integration-test
+
+
+integration-test:
+    FROM +netmiko-base
+    COPY tests/integration/integration-test.py .
+    WITH DOCKER \
+        --load sshd:latest=+sshd
+        RUN set -e; \
+            docker run --name ubuntu-sshd -p 2222:22 -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres sshd:latest; \
+            python integration-test.py;
+    END
+
+
+python-base:
+    FROM python:3.6-alpine3.13
+    RUN apk add --update --no-cache gcc musl-dev libffi-dev make openssl-dev rust cargo docker
+    RUN python -m pip install --upgrade pip
+
+
+netmiko-base:
+    FROM +python-base
+
+    COPY requirements*.txt setup.py README.md .
+    COPY --dir netmiko .
+
+    RUN pip install -r requirements.txt
+    RUN pip install -r requirements-dev.txt
+
+    RUN python setup.py install
+
+
+sshd:
+    FROM rastasheep/ubuntu-sshd:18.04
+    RUN echo "hello netmiko" > /root/data.txt

--- a/tests/integration/integration-test.py
+++ b/tests/integration/integration-test.py
@@ -1,0 +1,17 @@
+from netmiko import ConnectHandler
+
+linux = {
+    "device_type": "linux",
+    "ip": "127.0.0.1",
+    "username": "root",
+    "password": "root",
+    "port": 2222,
+    "verbose": True,
+}
+
+connection = ConnectHandler(**linux)
+output = connection.send_command("cat /root/data.txt")
+connection.disconnect()
+
+expected = "hello netmiko"
+assert output == expected, f'expected "{expected}", but got "{output}"'


### PR DESCRIPTION
- this creates an integration test that runs sshd in a dockerized ubuntu
container, and validates netmiko can connect using a username/password
and can issue a cat command.
- this makes use of earthly to run the test, this allows it to work
under github actions (or any other CI), as well as supports running it
locally via "earthly +integration-test"

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>